### PR TITLE
Fix shiny-server starting on IPv4-only hosts

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -29,7 +29,8 @@ RUN R -e "install.packages(c('shiny','shinythemes','maps','mapproj','leaflet','r
 # Housekeeping
 RUN cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ && \
     mkdir -p /var/log/shiny-server && \
-    chown shiny:shiny /var/lib/shiny-server
+    chown shiny:shiny /var/lib/shiny-server &&
+    sed -i 's/listen 3838/listen 3838 0.0.0.0/g' /etc/shiny-server/shiny-server.conf
 
 EXPOSE 3838
 

--- a/Containerfile
+++ b/Containerfile
@@ -17,9 +17,6 @@ RUN apt-get update &&\
     libudunits2-dev  && \
     apt-get clean
 
-# Install R Packages
-RUN R -e "install.packages(c('shiny','shinythemes','maps','mapproj','leaflet','rgdal','dplyr','sf','sp','flexdashboard','plotly','stringr','knitr'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
-
 # Install shiny-server deb package
 RUN SHINYVER=`curl https://download3.rstudio.org/ubuntu-18.04/x86_64/VERSION` && \
     wget --no-verbose "https://download3.rstudio.org/ubuntu-18.04/x86_64/shiny-server-$SHINYVER-amd64.deb" && \
@@ -28,6 +25,9 @@ RUN SHINYVER=`curl https://download3.rstudio.org/ubuntu-18.04/x86_64/VERSION` &&
     cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ && \
     mkdir -p /var/log/shiny-server && \
     chown shiny:shiny /var/lib/shiny-server
+
+# Install R Packages
+RUN R -e "install.packages(c('shiny','shinythemes','maps','mapproj','leaflet','rgdal','dplyr','sf','sp','flexdashboard','plotly','stringr','knitr'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
 
 EXPOSE 3838
 

--- a/Containerfile
+++ b/Containerfile
@@ -17,17 +17,15 @@ RUN apt-get update &&\
     libudunits2-dev  && \
     apt-get clean
 
+# Install R Packages
+RUN R -e "install.packages(c('shiny','shinythemes','maps','mapproj','leaflet','rgdal','dplyr','sf','sp','flexdashboard','plotly','stringr','knitr'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
+
 # Install shiny-server deb package
 RUN SHINYVER=`curl https://download3.rstudio.org/ubuntu-18.04/x86_64/VERSION` && \
     wget --no-verbose "https://download3.rstudio.org/ubuntu-18.04/x86_64/shiny-server-$SHINYVER-amd64.deb" && \
     gdebi -n "shiny-server-$SHINYVER-amd64.deb" && \
-    rm -f "shiny-server-$SHINYVER-amd64.deb" 
-
-# Install R Packages
-RUN R -e "install.packages(c('shiny','shinythemes','maps','mapproj','leaflet','rgdal','dplyr','sf','sp','flexdashboard','plotly','stringr','knitr'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
-
-# Housekeeping
-RUN cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ && \
+    rm -f "shiny-server-$SHINYVER-amd64.deb" && \
+    cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ && \
     mkdir -p /var/log/shiny-server && \
     chown shiny:shiny /var/lib/shiny-server && \
     sed -i 's/listen 3838/listen 3838 0.0.0.0/g' /etc/shiny-server/shiny-server.conf

--- a/Containerfile
+++ b/Containerfile
@@ -21,13 +21,15 @@ RUN apt-get update &&\
 RUN SHINYVER=`curl https://download3.rstudio.org/ubuntu-18.04/x86_64/VERSION` && \
     wget --no-verbose "https://download3.rstudio.org/ubuntu-18.04/x86_64/shiny-server-$SHINYVER-amd64.deb" && \
     gdebi -n "shiny-server-$SHINYVER-amd64.deb" && \
-    rm -f "shiny-server-$SHINYVER-amd64.deb" && \
-    cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ && \
-    mkdir -p /var/log/shiny-server && \
-    chown shiny:shiny /var/lib/shiny-server
+    rm -f "shiny-server-$SHINYVER-amd64.deb" 
 
 # Install R Packages
 RUN R -e "install.packages(c('shiny','shinythemes','maps','mapproj','leaflet','rgdal','dplyr','sf','sp','flexdashboard','plotly','stringr','knitr'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
+
+# Housekeeping
+RUN cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ && \
+    mkdir -p /var/log/shiny-server && \
+    chown shiny:shiny /var/lib/shiny-server
 
 EXPOSE 3838
 

--- a/Containerfile
+++ b/Containerfile
@@ -29,7 +29,7 @@ RUN R -e "install.packages(c('shiny','shinythemes','maps','mapproj','leaflet','r
 # Housekeeping
 RUN cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ && \
     mkdir -p /var/log/shiny-server && \
-    chown shiny:shiny /var/lib/shiny-server &&
+    chown shiny:shiny /var/lib/shiny-server && \
     sed -i 's/listen 3838/listen 3838 0.0.0.0/g' /etc/shiny-server/shiny-server.conf
 
 EXPOSE 3838

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                                 steps {
                                     sh 'podman run -it --rm localhost/$IMAGE_NAME Rscript -e "library(shiny); library(shinythemes); library(maps); library(mapproj); library(leaflet); library(rgdal); library(dplyr); library(sf); library(sp); library(flexdashboard); library(plotly); library(stringr)"'
                                     sh 'podman run -d --name=$IMAGE_NAME --rm -p 3838:3838 localhost/$IMAGE_NAME'
-                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 | grep -P "HTTP\\S+\\s200\\s+[A-Z ]+"'
+                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 | grep "Welcome to Shiny Server"'
                                 }
                                 post {
                                     always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                                 steps {
                                     sh 'podman run -it --rm localhost/$IMAGE_NAME Rscript -e "library(shiny); library(shinythemes); library(maps); library(mapproj); library(leaflet); library(rgdal); library(dplyr); library(sf); library(sp); library(flexdashboard); library(plotly); library(stringr)"'
                                     sh 'podman run -d --name=$IMAGE_NAME --rm -p 3838:3838 localhost/$IMAGE_NAME'
-                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 | grep "Welcome to Shiny Server"'
+                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 '
                                 }
                                 post {
                                     always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                                 steps {
                                     sh 'podman run -it --rm localhost/$IMAGE_NAME Rscript -e "library(shiny); library(shinythemes); library(maps); library(mapproj); library(leaflet); library(rgdal); library(dplyr); library(sf); library(sp); library(flexdashboard); library(plotly); library(stringr)"'
                                     sh 'podman run -d --name=$IMAGE_NAME --rm -p 3838:3838 localhost/$IMAGE_NAME'
-                                    sh 'curl -v http://localhost:3838/ 2>&1 | grep -P "HTTP\\S+\\s200\\s+[\\w\\s]+\\s*$"'
+                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 | grep -P "HTTP\\S+\\s200\\s+[\\w\\s]+\\s*$"'
                                 }
                                 post {
                                     always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                                 steps {
                                     sh 'podman run -it --rm localhost/$IMAGE_NAME Rscript -e "library(shiny); library(shinythemes); library(maps); library(mapproj); library(leaflet); library(rgdal); library(dplyr); library(sf); library(sp); library(flexdashboard); library(plotly); library(stringr)"'
                                     sh 'podman run -d --name=$IMAGE_NAME --rm -p 3838:3838 localhost/$IMAGE_NAME'
-                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 | grep -P "HTTP\\S+\\s200\\s+[\\w\\s]+\\s*$"'
+                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 | grep -P "HTTP\\S+\\s200\\s+[A-Z ]+"'
                                 }
                                 post {
                                     always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                                 steps {
                                     sh 'podman run -it --rm localhost/$IMAGE_NAME Rscript -e "library(shiny); library(shinythemes); library(maps); library(mapproj); library(leaflet); library(rgdal); library(dplyr); library(sf); library(sp); library(flexdashboard); library(plotly); library(stringr)"'
                                     sh 'podman run -d --name=$IMAGE_NAME --rm -p 3838:3838 localhost/$IMAGE_NAME'
-                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 | grep -P "HTTP\\S+\\s200\\s+[A-Z ]+"''
+                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 | grep -P "HTTP\\S+\\s200\\s+[A-Z ]+"'
                                 }
                                 post {
                                     always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                                 steps {
                                     sh 'podman run -it --rm localhost/$IMAGE_NAME Rscript -e "library(shiny); library(shinythemes); library(maps); library(mapproj); library(leaflet); library(rgdal); library(dplyr); library(sf); library(sp); library(flexdashboard); library(plotly); library(stringr)"'
                                     sh 'podman run -d --name=$IMAGE_NAME --rm -p 3838:3838 localhost/$IMAGE_NAME'
-                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 '
+                                    sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 | grep -P "HTTP\\S+\\s200\\s+[A-Z ]+"''
                                 }
                                 post {
                                     always {


### PR DESCRIPTION
This updates shiny-server to listen on IPv4 by default since not everything supports IPv6 yet.