### PR TITLE
Remove deprecated rgdal library

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,7 +18,7 @@ RUN apt-get update &&\
     apt-get clean
 
 # Install R Packages
-RUN R -e "install.packages(c('shiny','shinythemes','maps','mapproj','leaflet','rgdal','dplyr','sf','sp','flexdashboard','plotly','stringr','knitr'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
+RUN R -e "install.packages(c('shiny','shinythemes','maps','mapproj','leaflet','dplyr','sf','sp','flexdashboard','plotly','stringr','knitr'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
 
 # Install shiny-server deb package
 RUN SHINYVER=`curl https://download3.rstudio.org/ubuntu-18.04/x86_64/VERSION` && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
                             }
                             stage('Test') {
                                 steps {
-                                    sh 'podman run -it --rm localhost/$IMAGE_NAME Rscript -e "library(shiny); library(shinythemes); library(maps); library(mapproj); library(leaflet); library(rgdal); library(dplyr); library(sf); library(sp); library(flexdashboard); library(plotly); library(stringr)"'
+                                    sh 'podman run -it --rm localhost/$IMAGE_NAME Rscript -e "library(shiny); library(shinythemes); library(maps); library(mapproj); library(leaflet); library(dplyr); library(sf); library(sp); library(flexdashboard); library(plotly); library(stringr)"'
                                     sh 'podman run -d --name=$IMAGE_NAME --rm -p 3838:3838 localhost/$IMAGE_NAME'
                                     sh 'sleep 10 && curl -v http://localhost:3838/ 2>&1 | grep -P "HTTP\\S+\\s200\\s+[A-Z ]+"'
                                 }


### PR DESCRIPTION
Builds are broken for this due to [rgdal being unavailable](https://cran.r-project.org/web/packages/rgdal/index.html) in cran.  [rgdal was retired](https://rgdal.r-forge.r-project.org/) in favor of terra/sp.  AFAICT, there is no obvious need to ship this dependency any more.
